### PR TITLE
Fix compilation in FreeBSD port

### DIFF
--- a/src/oterm/app/chat_edit.py
+++ b/src/oterm/app/chat_edit.py
@@ -210,7 +210,7 @@ class ChatEdit(ModalScreen[str]):
                     with ScrollableContainer(id="tool-list"):
                         for tool_def in available_tool_defs:
                             yield Checkbox(
-                                label=f"{tool_def["tool"]['function']['name']}",
+                                label=f"{tool_def['tool']['function']['name']}",
                                 tooltip=f"{tool_def['tool']['function']['description']}",
                                 value=tool_def["tool"] in self.tools,
                                 classes="tool",


### PR DESCRIPTION
The compilation of version 0.6.2 failed in FreeBSD with the error:

*** Error compiling /usr/local/poudriere/ports/latest/misc/py-oterm/work-py311/stage/usr/local/lib/python3.11/site-packages/oterm/app/chat_edit.py...
  File "/usr/local/lib/python3.11/site-packages/oterm/app/chat_edit.py", line 213
    label=f"{tool_def["tool"][function][name]}",
                       ^^^^
SyntaxError: f-string: unmatched [

*** Error compiling /usr/local/poudriere/ports/latest/misc/py-oterm/work-py311/stage/usr/local/lib/python3.11/site-packages/oterm/app/chat_edit.py...
  File "/usr/local/lib/python3.11/site-packages/oterm/app/chat_edit.py", line 213
    label=f"{tool_def["tool"][function][name]}",
                       ^^^^
SyntaxError: f-string: unmatched [